### PR TITLE
Resolved issue of curves zoom mouse scrolling on Mozila firefox

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2095,7 +2095,7 @@ function BlackboxLogViewer() {
       }
     });
 
-    $(document).on("mousewheel", function (e) {
+    $(document).on("wheel", function (e) {
       if ($(e.target).hasClass("no-wheel")) {
         // prevent mousewheel scrolling on non scrollable elements.
         e.preventDefault();


### PR DESCRIPTION
Issue: The curves zoom by mouse wheel scrolling at curves legend did not work on Mozila Firefox browser. 
Solution: the older "mousewheel" event is changed to "wheel" event. 
